### PR TITLE
Lbe 121 assignment module bug 4

### DIFF
--- a/src/main/java/com/numpyninja/lms/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/numpyninja/lms/exception/GlobalExceptionHandler.java
@@ -2,8 +2,10 @@ package com.numpyninja.lms.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -11,7 +13,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.numpyninja.lms.config.ApiResponse;
+
 
 import javax.validation.ConstraintViolationException;
 
@@ -60,5 +65,15 @@ public class GlobalExceptionHandler {
 		String message = ex.getMessage();
 		ApiResponse apiResponse = new ApiResponse(message, false);
 		return new ResponseEntity<>(apiResponse, HttpStatus.UNAUTHORIZED);
+	}
+	
+	@ExceptionHandler(InvalidFormatException.class)
+	public ResponseEntity<ApiResponse> InvalidFormatExceptionExceptionHandler(InvalidFormatException ex) {
+		String message = ex.getMessage();
+		if(message.contains("java.util.Date")) {
+			message = "Invalid DateTime format";
+		}
+		ApiResponse apiResponse = new ApiResponse(message, false);
+		return new ResponseEntity<>(apiResponse, HttpStatus.BAD_REQUEST);
 	}
 }

--- a/src/main/java/com/numpyninja/lms/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/numpyninja/lms/exception/GlobalExceptionHandler.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.numpyninja.lms.config.ApiResponse;
 
+import java.util.Date;
 
 import javax.validation.ConstraintViolationException;
 
@@ -70,7 +71,8 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(InvalidFormatException.class)
 	public ResponseEntity<ApiResponse> InvalidFormatExceptionExceptionHandler(InvalidFormatException ex) {
 		String message = ex.getMessage();
-		if(message.contains("java.util.Date")) {
+		if(ex.getTargetType().equals(Date.class)) //&& message.contains("Cannot deserialize value of type 'java.util.Date'")) 
+		{
 			message = "Invalid DateTime format";
 		}
 		ApiResponse apiResponse = new ApiResponse(message, false);


### PR DESCRIPTION
Issue - Invalid format of date/time in AssignmentDTO was giving exception with correct code (Bad Request) but with original stack trace and message.
"timestamp": "2023-08-03716:42:48.474+00: 00'
"status"
400,
"error"
"Bad Request"
"trace":
"org. springframework.http.converter. HttpMessageNotReadableException: JSON parse error: Cannot deserialize value of type 'java. util. Date' from String \"25-09-2023\"; not a valid representation (error: Failed to parse Date value '25-09-2023': Cannot parse date \"25-09-2023\": not compatible with any of standard forms (\ "yyyy-MM-dd'T'HH:mm:ss.SSSX\", \"yyyy-MM-dd'T'HH:mm:ss.SSS\", \ "EEE, dd MMM yyyy HH:mm:ss zzz\" , \ "yyyy-MM-dd\")) ; nested exception is com. fasterxmI. jackson.databind.exc. InvalidFormatException: Cannot deserialize value of type 'java.util. Date' from String \ "25-09-2023\": not a valid representation (error: Failed to parse Date value '25-09-2023': Cannot parse date \ "25-09-2023\": not compatible with any of standard forms (\ "yyyy-MM-dd'T'HH:mm:ss.SSSX\", \"yyyy-MM-dd'T 'HH:mm: ss. SSS\", \"EEE, dd MMM yyyy HH: mm:ss zzz\", \"yyyy-MM-dd\')) \n at [Source: (PushbackInputStream) ; line: 5, column: 15] (through reference chain: com.numpyninja.1ms.dto.AssignmentDto[\"dueDate\"])\n\tat org. springframework.http.converter.son.AbstractJackson2HttpMessageConverter.readJavaType (AbstractJackson2HttpMessageConverter. java:389) \n\tat org.springframework.http. converter.json.AbstractJackson2HttpMessageConverter.read (AbstractJackson2HttpMessageConverter. java:342)\n\tat org.springframework.web.servlet.mvc.method.annotation.AbstractMessageConverterMethodArgumentResolver. readWithMessageConverters(AbstractMessageConverterMethodArgumentResolver.java:185)\n\tatorg.springframework.web.servlet.mvc.method.annotation.
RequestResponseBodyMethodProcessor.readWithMessageConverters(RequestResponseBodyMethodProcessor.java:160)\n\tatorg.springframework.web.servlet.mvc.method. annotation. RequestResponseBodyMethodProcessor.resolveArgument(RequestResponseBodyMethodProcessor.java:133)\n\tatorg.springframework.web.method.support.
HandlerMethodArgumentResolverComposite.resolveArgument(HandlerMethodArgumentResolverComposite.java:121)\n\tatorg.springframework.web.method.support.
InvocableHandlerMethod.getMethodArgumentValues(InvocableHandlerMethod.java:179)\n\tatorg.springframework.web.method.support.InvocableHandlerMethod. invokeForRequest(InvocableHandlerMethod.java:146)\n\tatorg.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle
(ServletInvocableHandlerMethod. java:117) \n\tat org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod
(RequestMappingHandlerAdapter. java: 895) \n\tat org. springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal
(RequestMappingHandlerAdapter. java:808) \n\tat org. springframework.web. servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.
java: 87) \n\tat org. springframework.web.servlet. DispatcherServlet. doDispatch (DispatcherServlet. java:1067) \n\tat org. springframework.web. servlet.
DispatcherServlet.doService(DispatcherServlet.java:963\n\tatorg.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)\n\tat org. springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:909)\n\tatjavax.servlet.http.HttpServlet…service(HttpServlet.java:681)\n\tatorg. springframework.web.servlet…FrameworkServlet.service(FrameworkServlet.java:883)\n\tatjavax.servlet.http.HttpServlet.service(HttpServlet.java:764)\n\tatorg. apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227)\n\tatorg.apache.catalina.core.ApplicationFilterChain.doFilter
(ApplicationFilterChain. java:162) \n\tat org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)\n\tat org.apache.catalina.core.
ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189\n\tatorg.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.


Fix - Handled InputFormatException in GlobalExceptionHandler and returning "Invalid date/time format" message if dateTime format is incorrect,  instead of full trace and the exception message.
{
    "message": "Invalid DateTime format",
    "success": false
}