### PR TITLE
 LS-22  Updation of a role for a User is not reflected in getting users by id

### DIFF
--- a/src/main/java/com/numpyninja/lms/repository/UserRoleMapRepository.java
+++ b/src/main/java/com/numpyninja/lms/repository/UserRoleMapRepository.java
@@ -59,6 +59,8 @@ public interface UserRoleMapRepository  extends JpaRepository <UserRoleMap, Long
 
 	@Query("Select u FROM UserRoleMap u WHERE u.userRoleStatus=:userRoleStatus")
     List<UserRoleMap> findByUserRoleStatus(@Param(value="userRoleStatus") String userRoleStatus);
+
+	 List<UserRoleMap> findByRole_RoleId(String roleId);
 }
 
 

--- a/src/main/java/com/numpyninja/lms/services/UserServices.java
+++ b/src/main/java/com/numpyninja/lms/services/UserServices.java
@@ -583,7 +583,7 @@ public class UserServices implements UserDetailsService {
                 toUpdatedRole.setRole(userRole); //Role Id R01/R02/R03
                 toUpdatedRole.setUser(existingUser); //user Id U01/U02
                         				  
-                toUpdatedRole = userRoleMapRepository.save(toUpdatedRole);
+                toUpdatedRole = userRoleMapRepository.save(toUpdatedRole);                              
              }
           }
           else 
@@ -917,12 +917,12 @@ public class UserServices implements UserDetailsService {
     public List<UserDto> getUsersByRoleID(String roleId){
         Role role = roleRepository.findById(roleId)
                 .orElseThrow(() -> new ResourceNotFoundException("RoleID " + roleId + " not found"));
-        List<UserRoleProgramBatchMap> userRoleProgramBatchMapList = userRoleProgramBatchMapRepository.findByRole_RoleId(roleId);
-        if (userRoleProgramBatchMapList.isEmpty()) {
+        List<UserRoleMap> userRoleMapList = userRoleMapRepository.findByRole_RoleId(roleId);
+        if (userRoleMapList.isEmpty()) {
             throw new ResourceNotFoundException("No Users found for the given role ID: " + roleId);
         }
-        List<UserDto> userdto=  userRoleProgramBatchMapList.stream()
-                .map(UserRoleProgramBatchMap::getUser)
+        List<UserDto> userdto=  userRoleMapList.stream()
+                .map(UserRoleMap::getUser)
                 .map(user -> userMapper.userDtos(Arrays.asList(user)).get(0))
                 .collect(Collectors.toList());
         return userdto;


### PR DESCRIPTION
When we update the Role Id for a user, the ID gets updated but when we try to get the list of users for the same role ID the recently updated user is not getting listed.

Steps to reproduce:

Create put request for the end point /users/roleId/U08 with request body { "userRoleList": [     "R01"   ] }

Create get request for the end point /users/roles/R01