### PR TITLE
LS-29-Unable-to-update-email-in-update-user-endpoint

### DIFF
--- a/src/main/java/com/numpyninja/lms/services/UserServices.java
+++ b/src/main/java/com/numpyninja/lms/services/UserServices.java
@@ -466,7 +466,16 @@ public class UserServices implements UserDetailsService {
             }
 
             User updatedUser = userRepository.save(toBeupdatedUser);
-            UserDto updatedUserDto = userMapper.userDto(updatedUser);
+
+            //Bug - returning null value for userLoginEmail in userDto repsonse
+            //Bugfix - returning the updated value of userLoginEmail on updating the userLoginEmail field
+            Optional<UserLogin> userLogin = userLoginRepository.findByUserUserId(userId);
+            userLogin.get().setUserId(updatedUser.getUserId());
+            userLogin.get().setUser(updatedUser);
+            userLogin.get().setUserLoginEmail(updateuserDto.getUserLoginEmail());
+            userLogin.get().setLastModTime(new Timestamp(utilDate.getTime()));
+            UserLogin toBeupdatedUserLogin = userLoginRepository.save(userLogin.get());
+            UserDto updatedUserDto = userLoginMapper.toUserDto(toBeupdatedUserLogin);
             return updatedUserDto;
         }
     }

--- a/src/test/java/com/numpyninja/lms/services/UserServicesTest.java
+++ b/src/test/java/com/numpyninja/lms/services/UserServicesTest.java
@@ -484,7 +484,10 @@ class UserServicesTest {
         mockUserDto.setUserMiddleName("APJ");
         given(userMapper.user(mockUserDto)).willReturn(mockUser);
         given(userRepo.save(mockUser)).willReturn(mockUser);
-        given(userMapper.userDto(mockUser)).willReturn(mockUserDto);
+        given(userLoginRepository.findByUserUserId(mockUser.getUserId())).willReturn(Optional.of(mockUserLogin));
+        mockUserLogin.setUserLoginEmail("abdul.kalam@mail.com");
+        given(userLoginRepository.save(mockUserLogin)).willReturn(mockUserLogin);
+        given(userLoginMapper.toUserDto(mockUserLogin)).willReturn(mockUserDto);
 
         //when
         UserDto userDto = userService.updateUser(mockUserDto, mockUser.getUserId());
@@ -492,6 +495,7 @@ class UserServicesTest {
         //then
         assertThat(userDto).isNotNull();
         assertThat(userDto.getUserMiddleName()).isEqualTo("APJ");
+        assertThat(userDto.getUserLoginEmail()).isEqualTo("abdul.kalam@gmail.com");
 
     }
 


### PR DESCRIPTION
LS 29 : Unable to update email in update user endpoint

Description :
Not able to update email when we are updating the user information using /users/{userId} endpoint

Steps to reproduce : 
Create PUT request using the endPoint users/U07 and request body 
When you send the request, the user email shows “Null” in the response
